### PR TITLE
Fix typo in background comment

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 /* ──────────────────────────────────────────────────
    TAB SUSPENDER — Service Worker (Manifest V3)
    ──────────────────────────────────────────────────
-   1  Configuración y helper
+   1  Configuración y helpers
    2  Instalación (alarma + menú)
    3  UI (icono·comandos·menú)
    4  Mensajes: SYNC_ALL  | RESTORE_TAB


### PR DESCRIPTION
## Summary
- fix Spanish comment referencing configuration helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841944ffb448331baca7473d710c90f