### PR TITLE
Fix grid alignment to stop windows expanding together

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -286,12 +286,14 @@
       grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
       gap: 20px;
       margin-top: 20px;
+      align-items: start;
     }
 
     @media(max-width: 1200px) {
       #cards {
         grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
         gap: 16px;
+        align-items: start;
       }
     }
 
@@ -299,6 +301,7 @@
       #cards {
         grid-template-columns: 1fr;
         gap: 16px;
+        align-items: start;
       }
     }
 
@@ -672,10 +675,11 @@
         min-width: auto;
       }
 
-      #cards {
-        grid-template-columns: 1fr;
-        gap: 12px;
-      }
+        #cards {
+          grid-template-columns: 1fr;
+          gap: 12px;
+          align-items: start;
+        }
 
       .tab-url {
         display: none;


### PR DESCRIPTION
## Summary
- prevent grid items from stretching to row height so window cards expand independently

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684528715dd483318f5560151b013431