### PR TITLE
Handle closed windows and keep tab order

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -322,6 +322,14 @@
       box-shadow: var(--shadow-hover);
     }
 
+    .card.closed {
+      opacity: 0.6;
+    }
+
+    .card.closed .card-header {
+      background: linear-gradient(135deg, #9e9e9e, #757575);
+    }
+
     .card-header {
       display: flex;
       align-items: center;
@@ -387,7 +395,7 @@
 
 
     .card-body {
-      max-height: 400px;
+      max-height: none;
       overflow-y: auto;
       background: var(--card-bg);
     }


### PR DESCRIPTION
## Summary
- maintain tab order by storing and sorting by tab index
- persist windows even when closed and show them as disabled
- adjust card height dynamically to display up to 15 tabs without scroll

## Testing
- `node --version`
- `node --check background.js`
- `node --check dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68452c0267d083318d3311a5dff913c8